### PR TITLE
Adopted to AWS Robomaker

### DIFF
--- a/champ_base/CMakeLists.txt
+++ b/champ_base/CMakeLists.txt
@@ -65,6 +65,10 @@ include_directories(
   ${catkin_INCLUDE_DIRS}
 )
 
+install(DIRECTORY config
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)
+
 add_library(quadruped_controller src/quadruped_controller.cpp)
 add_library(message_relay src/message_relay.cpp)
 add_library(state_estimation src/state_estimation.cpp)

--- a/champ_base/CMakeLists.txt
+++ b/champ_base/CMakeLists.txt
@@ -62,6 +62,8 @@ endif()
 include_directories(
   include
   ${champ_INCLUDE_DIRS}
+  ${champ_INCLUDE_DIRS}/champ/
+  ${champ_INCLUDE_DIRS}/champ/champ/
   ${catkin_INCLUDE_DIRS}
 )
 

--- a/champ_base/package.xml
+++ b/champ_base/package.xml
@@ -13,6 +13,7 @@
   <exec_depend>roslaunch</exec_depend>
   <depend>roscpp</depend>
   <depend>rospy</depend>
+  <depend>champ</depend>
   <depend>champ_msgs</depend>
   <depend>visualization_msgs</depend>
   <depend>geometry_msgs</depend>

--- a/champ_bringup/CMakeLists.txt
+++ b/champ_bringup/CMakeLists.txt
@@ -7,3 +7,7 @@ find_package(catkin
 )
 
 catkin_package()
+
+install(DIRECTORY launch
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)

--- a/champ_config/CMakeLists.txt
+++ b/champ_config/CMakeLists.txt
@@ -4,3 +4,7 @@ project(champ_config)
 find_package(catkin REQUIRED COMPONENTS)
 
 catkin_package()
+
+install(DIRECTORY config launch maps worlds
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)

--- a/champ_description/CMakeLists.txt
+++ b/champ_description/CMakeLists.txt
@@ -6,6 +6,6 @@ find_package(catkin REQUIRED COMPONENTS)
 
 catkin_package()
 
-install(DIRECTORY meshes launch urdf
+install(DIRECTORY meshes launch urdf rviz
     DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )

--- a/champ_gazebo/CMakeLists.txt
+++ b/champ_gazebo/CMakeLists.txt
@@ -22,7 +22,6 @@ catkin_package(
 
 install(PROGRAMS
   scripts/imu_sensor.py
-  scripts/joints_controller.py
   scripts/odometry_tf.py
   scripts/odometry.py
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
@@ -47,4 +46,12 @@ install(TARGETS
     ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
     LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
     RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
+install(DIRECTORY launch config
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)
+
+install(DIRECTORY worlds/
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/worlds
 )

--- a/champ_gazebo/CMakeLists.txt
+++ b/champ_gazebo/CMakeLists.txt
@@ -30,6 +30,8 @@ install(PROGRAMS
 include_directories(
   include
   ${champ_INCLUDE_DIRS}
+  ${champ_INCLUDE_DIRS}/champ/
+  ${champ_INCLUDE_DIRS}/champ/champ/
   ${catkin_INCLUDE_DIRS}
   ${GAZEBO_INCLUDE_DIRS}
 )

--- a/champ_navigation/CMakeLists.txt
+++ b/champ_navigation/CMakeLists.txt
@@ -8,3 +8,7 @@ catkin_package()
 include_directories(
   ${catkin_INCLUDE_DIRS}
 )
+
+install(DIRECTORY launch maps param rviz
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)


### PR DESCRIPTION
Hello! Our robotics group has adopted the champ repo for AWS Robomaker. Now, the package can be deployed on the cloud using git clone command and build by colcon. In addition, we tested that the package works with catkin correctly as well. 