### PR TITLE
Fix joint message iterating in state estimation

### DIFF
--- a/champ_base/src/state_estimation.cpp
+++ b/champ_base/src/state_estimation.cpp
@@ -78,7 +78,7 @@ void StateEstimation::synchronized_callback_(const sensor_msgs::JointStateConstP
 
     float current_joint_positions[12];
 
-    for(size_t i = 0; i < 12; i++)
+    for(size_t i = 0; i < joints_msg->name.size(); i++)
     {
         std::vector<std::string>::iterator itr = std::find(joint_names_.begin(), joint_names_.end(), joints_msg->name[i]);
 


### PR DESCRIPTION
Iterate all joints when updating joint states, to work properly with other mechanisims attached.

When assemble an arm with the quadruped base and create another controller for arm, message published by joint states controller may just not begin with joints of the quadruped base, in which case the updating process goes wrong (and causes  undefined behavior maybe?).