### PR TITLE
Fix state estimation in case no foot is in contact

### DIFF
--- a/champ_base/src/state_estimation.cpp
+++ b/champ_base/src/state_estimation.cpp
@@ -187,7 +187,7 @@ void StateEstimation::publishBaseToFootprint_(const ros::TimerEvent& event)
     base_.getFootPositions(current_foot_positions_);
 
     visualization_msgs::MarkerArray marker_array;
-    float robot_height = 0.0;
+    float robot_height = 0.0, all_height = 0.0;
     int foot_in_contact = 0;
 
     for(size_t i = 0; i < 4; i++)
@@ -198,6 +198,13 @@ void StateEstimation::publishBaseToFootprint_(const ros::TimerEvent& event)
             robot_height += current_foot_positions_[i].Z();
             foot_in_contact++;
         }
+        all_height += current_foot_positions_[i].Z();
+    }
+
+    if (foot_in_contact == 0)
+    {
+      robot_height = all_height;
+      foot_in_contact = 4;
     }
 
 	if(foot_publisher_.getNumSubscribers())


### PR DESCRIPTION
E.g. robot being dropped from height, or robot lying on its side.

Without this fix, NaN is published in the z coordinate of base_to_footprint, which then spoils all the rest of localization.