### PR TITLE
Make state estimation work better in case the robot is not touching with all feet

### DIFF
--- a/champ_base/include/state_estimation.h
+++ b/champ_base/include/state_estimation.h
@@ -50,6 +50,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <message_filters/subscriber.h>
 #include <message_filters/synchronizer.h>
 #include <message_filters/sync_policies/approximate_time.h>
+#include <sensor_msgs/Imu.h>
 
 class StateEstimation
 {
@@ -59,7 +60,8 @@ class StateEstimation
 
     message_filters::Subscriber<sensor_msgs::JointState> joint_states_subscriber_;
     message_filters::Subscriber<champ_msgs::ContactsStamped> foot_contacts_subscriber_;
-    
+    ros::Subscriber imu_subscriber_;
+
     ros::Publisher footprint_to_odom_publisher_;
     ros::Publisher base_to_footprint_publisher_;
     ros::Publisher foot_publisher_;
@@ -78,6 +80,7 @@ class StateEstimation
     float heading_;
     ros::Time last_vel_time_;
     ros::Time last_sync_time_;
+    sensor_msgs::ImuConstPtr last_imu_;
 
     champ::GaitConfig gait_config_;
 
@@ -91,10 +94,12 @@ class StateEstimation
     std::string base_footprint_frame_;
     std::string base_link_frame_;
     bool close_loop_odom_;
+    bool orientation_from_imu_;
 
     void publishFootprintToOdom_(const ros::TimerEvent& event);
     void publishBaseToFootprint_(const ros::TimerEvent& event);
     void synchronized_callback_(const sensor_msgs::JointStateConstPtr&, const champ_msgs::ContactsStampedConstPtr&);
+    void imu_callback_(const sensor_msgs::ImuConstPtr&);
 
     visualization_msgs::Marker createMarker_(geometry::Transformation foot_pos, int id, std::string frame_id);
 

--- a/champ_bringup/launch/bringup.launch
+++ b/champ_bringup/launch/bringup.launch
@@ -16,6 +16,7 @@
     <arg name="publish_joint_control"  default="true" />
     <arg name="publish_foot_contacts"  default="true" />
     <arg name="close_loop_odom"        default="false" />
+    <arg name="orientation_from_imu"   default="$(arg gazebo)" />
 
     <group ns="$(arg robot_name)">
         <param name="tf_prefix" value="$(arg robot_name)"/>
@@ -59,6 +60,7 @@
         <!-- ==================== STATE ESTIMATION ==================== -->
         <node pkg="champ_base" name="state_estimator" type="state_estimation_node" output="screen">
             <param name="close_loop_odom" value="$(arg close_loop_odom)" />
+            <param name="orientation_from_imu" value="$(arg orientation_from_imu)" />
         </node>
 
         <node pkg="robot_localization" type="ekf_localization_node" name="base_to_footprint_ekf"> 


### PR DESCRIPTION
I did some improvements to the state estimation node that result in estimating the body orientation more or less correctly even if the robot is not standing on all feet.

There are two cases:

1. IMU provides orientation and `use_orientation_from_imu` param is set to true. In this case, orientation of the body is determined by the feet in case 3 or 4 are touching, and otherwise it uses the Z axis from IMU. If two feet are touching, they are used to define roll of the base_footprint plane. In case 1 or zero legs are touching, the whole orientation is just taken from IMU and aligned to the robot base_link projection along the IMU Z vector.
2. IMU does not provide orientation data. In this case, the Z vector is copied over from the base_link frame, and otherwise, the behavior is the same as in case 1.

I automatically enabled reading the orientation from IMU when running in Gazebo, as Gazebo provides orientation. What more, this orientation is not affected by any kind of noise.

Behavior with this PR (rviz set to base_footprint fixed frame):

https://user-images.githubusercontent.com/182533/112215091-3de21180-8c20-11eb-8b40-1192dacb9066.mp4

Original behavior:

https://user-images.githubusercontent.com/182533/112215146-4f2b1e00-8c20-11eb-80db-53cd9bed31f4.mp4

I hope I understood the base_footprint frame meaning well. I imagine it as the frame that would be the result of a top-down projection of the robot to a flat ground plane.

Of course, I'm not sure if this wouldn't break some code relying on the properties of the worse performing state estimation. But I think it could be worth considering.