### PR TITLE
Fix bringup launch error on ROS 2 Galactic

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ You don't need a physical robot to run the following demos. If you're building a
 
 #### 2.1.1 Run the base driver:
 
-    ros2 launch champ_config bringup.launch 
+    ros2 launch champ_config bringup.launch.py
 
     (In another terminal) rviz2 -d src/champ/champ_description/rviz/urdf_viewer.rviz
 

--- a/champ_config/launch/bringup.launch.py
+++ b/champ_config/launch/bringup.launch.py
@@ -22,7 +22,15 @@ from launch_ros.substitutions import FindPackageShare
 
 def generate_launch_description():
     this_package = FindPackageShare('champ_config')
-
+    joints_config = PathJoinSubstitution(
+        [this_package, 'config', 'joints', 'joints.yaml']
+    )
+    gait_config = PathJoinSubstitution(
+        [this_package, 'config', 'gait', 'gait.yaml']
+    )
+    links_config = PathJoinSubstitution(
+        [this_package, 'config', 'links', 'links.yaml']
+    )
     bringup_launch_path = PathJoinSubstitution(
         [FindPackageShare('champ_bringup'), 'launch', 'bringup.launch.py']
     )
@@ -62,7 +70,10 @@ def generate_launch_description():
                 "hardware_connected": LaunchConfiguration("hardware_connected"),
                 "publish_foot_contacts": "true",
                 "close_loop_odom": "true",
-                "joint_controller_topic": "joint_group_effort_controller/joint_trajectory"
+                "joint_controller_topic": "joint_group_effort_controller/joint_trajectory",
+                "joints_map_path": joints_config,
+                "links_map_path": links_config,
+                "gait_config_path": gait_config
             }.items(),
         )
     ])


### PR DESCRIPTION
There is an error launching "bringup.launch.py" on Galactic. 

I guess this error is same as https://github.com/chvmp/champ/issues/98

```
$ ros2 launch champ_config bringup.launch.py 
[INFO] [launch]: All log files can be found below /home/ubuntu/.ros/log/2022-08-22-16-12-27-645454-025b43e2800b-11458
[INFO] [launch]: Default logging verbosity is set to INFO
[WARNING] [launch_ros.actions.node]: Parameter file path is not a file: .
[WARNING] [launch_ros.actions.node]: Parameter file path is not a file: .
[WARNING] [launch_ros.actions.node]: Parameter file path is not a file: .
[WARNING] [launch_ros.actions.node]: Parameter file path is not a file: .
[WARNING] [launch_ros.actions.node]: Parameter file path is not a file: .
[WARNING] [launch_ros.actions.node]: Parameter file path is not a file: .
[INFO] [robot_state_publisher-1]: process started with pid [11465]
[INFO] [quadruped_controller_node-2]: process started with pid [11467]
[INFO] [state_estimation_node-3]: process started with pid [11469]
[INFO] [ekf_node-4]: process started with pid [11471]
[INFO] [ekf_node-5]: process started with pid [11473]
[robot_state_publisher-1] [WARN] [1661184748.490026560] [robot_state_publisher]: use_tf_static is deprecated and will be removed in the future
[ekf_node-4] [WARN] [1661184748.503605616] [base_to_footprint_ekf]: Warning: Some linear velocity entries in parameter imu0_config are listed true, but an sensor_msgs/Imu contains no information about linear velocities
[ekf_node-4] Warning: imu/data is listed as an input topic, but all its update variables are false
[state_estimation_node-3] [INFO] [1661184748.506821219] [rclcpp]: Successfully parsed urdf file
[state_estimation_node-3] terminate called after throwing an instance of 'std::runtime_error'
[robot_state_publisher-1] Link base_inertia had 0 children
[robot_state_publisher-1] Link camera_link had 2 children
[robot_state_publisher-1] Link camera_depth_frame had 1 children
[robot_state_publisher-1] Link camera_depth_optical_frame had 0 children
[robot_state_publisher-1] Link camera_rgb_frame had 1 children
[robot_state_publisher-1] Link camera_rgb_optical_frame had 0 children
[robot_state_publisher-1] Link hokuyo_frame had 0 children
[robot_state_publisher-1] Link imu_link had 0 children
[robot_state_publisher-1] Link lf_hip_debug_link had 0 children
[robot_state_publisher-1] Link lf_hip_link had 1 children
[robot_state_publisher-1] Link lf_upper_leg_link had 1 children
[robot_state_publisher-1] Link lf_lower_leg_link had 1 children
[robot_state_publisher-1] Link lf_foot_link had 0 children
[robot_state_publisher-1] Link lh_hip_debug_link had 0 children
[robot_state_publisher-1] Link lh_hip_link had 1 children
[robot_state_publisher-1] Link lh_upper_leg_link had 1 children
[robot_state_publisher-1] Link lh_lower_leg_link had 1 children
[robot_state_publisher-1] Link lh_foot_link had 0 children
[robot_state_publisher-1] Link rf_hip_debug_link had 0 children
[robot_state_publisher-1] Link rf_hip_link had 1 children
[robot_state_publisher-1] Link rf_upper_leg_link had 1 children
[robot_state_publisher-1] Link rf_lower_leg_link had 1 children
[robot_state_publisher-1] Link rf_foot_link had 0 children
[robot_state_publisher-1] Link rh_hip_debug_link had 0 children
[robot_state_publisher-1] Link rh_hip_link had 1 children
[robot_state_publisher-1] Link rh_upper_leg_link had 1 children
[robot_state_publisher-1] Link rh_lower_leg_link had 1 children
[robot_state_publisher-1] Link rh_foot_link had 0 children
[robot_state_publisher-1] [INFO] [1661184748.507163123] [robot_state_publisher]: got segment base_inertia
[robot_state_publisher-1] [INFO] [1661184748.507184858] [robot_state_publisher]: got segment base_link
[robot_state_publisher-1] [INFO] [1661184748.507190813] [robot_state_publisher]: got segment camera_depth_frame
[robot_state_publisher-1] [INFO] [1661184748.507195344] [robot_state_publisher]: got segment camera_depth_optical_frame
[robot_state_publisher-1] [INFO] [1661184748.507199840] [robot_state_publisher]: got segment camera_link
[robot_state_publisher-1] [INFO] [1661184748.507204193] [robot_state_publisher]: got segment camera_rgb_frame
[robot_state_publisher-1] [INFO] [1661184748.507208617] [robot_state_publisher]: got segment camera_rgb_optical_frame
[robot_state_publisher-1] [INFO] [1661184748.507212970] [robot_state_publisher]: got segment hokuyo_frame
[robot_state_publisher-1] [INFO] [1661184748.507217312] [robot_state_publisher]: got segment imu_link
[robot_state_publisher-1] [INFO] [1661184748.507221482] [robot_state_publisher]: got segment lf_foot_link
[robot_state_publisher-1] [INFO] [1661184748.507225762] [robot_state_publisher]: got segment lf_hip_debug_link
[robot_state_publisher-1] [INFO] [1661184748.507230054] [robot_state_publisher]: got segment lf_hip_link
[robot_state_publisher-1] [INFO] [1661184748.507234295] [robot_state_publisher]: got segment lf_lower_leg_link
[robot_state_publisher-1] [INFO] [1661184748.507238548] [robot_state_publisher]: got segment lf_upper_leg_link
[robot_state_publisher-1] [INFO] [1661184748.507242737] [robot_state_publisher]: got segment lh_foot_link
[robot_state_publisher-1] [INFO] [1661184748.507246913] [robot_state_publisher]: got segment lh_hip_debug_link
[robot_state_publisher-1] [INFO] [1661184748.507251044] [robot_state_publisher]: got segment lh_hip_link
[robot_state_publisher-1] [INFO] [1661184748.507255242] [robot_state_publisher]: got segment lh_lower_leg_link
[robot_state_publisher-1] [INFO] [1661184748.507259611] [robot_state_publisher]: got segment lh_upper_leg_link
[robot_state_publisher-1] [INFO] [1661184748.507263920] [robot_state_publisher]: got segment rf_foot_link
[robot_state_publisher-1] [INFO] [1661184748.507268324] [robot_state_publisher]: got segment rf_hip_debug_link
[robot_state_publisher-1] [INFO] [1661184748.507272479] [robot_state_publisher]: got segment rf_hip_link
[robot_state_publisher-1] [INFO] [1661184748.507276786] [robot_state_publisher]: got segment rf_lower_leg_link
[robot_state_publisher-1] [INFO] [1661184748.507280932] [robot_state_publisher]: got segment rf_upper_leg_link
[robot_state_publisher-1] [INFO] [1661184748.507285052] [robot_state_publisher]: got segment rh_foot_link
[robot_state_publisher-1] [INFO] [1661184748.507289204] [robot_state_publisher]: got segment rh_hip_debug_link
[robot_state_publisher-1] [INFO] [1661184748.507293497] [robot_state_publisher]: got segment rh_hip_link
[robot_state_publisher-1] [INFO] [1661184748.507297815] [robot_state_publisher]: got segment rh_lower_leg_link
[robot_state_publisher-1] [INFO] [1661184748.507302031] [robot_state_publisher]: got segment rh_upper_leg_link
[state_estimation_node-3]   what():  No links config file provided
[quadruped_controller_node-2] [INFO] [1661184748.509707143] [rclcpp]: Successfully parsed urdf file
[quadruped_controller_node-2] terminate called after throwing an instance of 'std::runtime_error'
[quadruped_controller_node-2]   what():  No links config file provided
[ERROR] [state_estimation_node-3]: process has died [pid 11469, exit code -6, cmd '/home/ubuntu/ros_ws/install/champ_base/lib/champ_base/state_estimation_node --ros-args --params-file /tmp/launch_params_wtmvuro8 --params-file /tmp/launch_params_5os4u6l0 --params-file /tmp/launch_params_mh_kqfy6'].
[ERROR] [quadruped_controller_node-2]: process has died [pid 11467, exit code -6, cmd '/home/ubuntu/ros_ws/install/champ_base/lib/champ_base/quadruped_controller_node --ros-args --params-file /tmp/launch_params_ic66do8b --params-file /tmp/launch_params_qids7z8_ --params-file /tmp/launch_params_d9gkozzd --params-file /tmp/launch_params_vlerediz --params-file /tmp/launch_params_9w2w0dyf --params-file /tmp/launch_params_xzx8sqrq --params-file /tmp/launch_params_pn1w9mig -r /cmd_vel/smooth:=/cmd_vel'].
^C[WARNING] [launch]: user interrupted with ctrl-c (SIGINT)
[ekf_node-4] [INFO] [1661184948.006466411] [rclcpp]: signal_handler(signal_value=2)
[ekf_node-5] [INFO] [1661184948.006439825] [rclcpp]: signal_handler(signal_value=2)
[robot_state_publisher-1] [INFO] [1661184948.006589951] [rclcpp]: signal_handler(signal_value=2)
[INFO] [robot_state_publisher-1]: process has finished cleanly [pid 11465]
[INFO] [ekf_node-4]: process has finished cleanly [pid 11471]
[INFO] [ekf_node-5]: process has finished cleanly [pid 11473]
```

