### PR TITLE
Enable RViz2 launch option

### DIFF
--- a/champ_bringup/launch/bringup.launch.py
+++ b/champ_bringup/launch/bringup.launch.py
@@ -31,6 +31,7 @@ def generate_launch_description():
     joints_config = os.path.join(config_pkg_share, "config/joints/joints.yaml")
     gait_config = os.path.join(config_pkg_share, "config/gait/gait.yaml")
     links_config = os.path.join(config_pkg_share, "config/links/links.yaml")
+    rviz_config = os.path.join(descr_pkg_share, "rviz/urdf_viewer.rviz")
     default_model_path = os.path.join(descr_pkg_share, "urdf/champ.urdf.xacro")
 
     declare_use_sim_time = DeclareLaunchArgument(
@@ -213,14 +214,24 @@ def generate_launch_description():
         ],
         remappings=[("odometry/filtered", "odom")],
     )
-    
+
+    rviz2 = Node(
+        package='rviz2',
+        namespace='',
+        executable='rviz2',
+        name='rviz2',
+        arguments=['-d', rviz_config],
+        condition=IfCondition(LaunchConfiguration("rviz"))
+    )
+
+
     return LaunchDescription(
         [
             declare_use_sim_time,
             declare_description_path,
-            declare_joints_map_path, 
-            declare_links_map_path, 
-            declare_gait_config_path, 
+            declare_joints_map_path,
+            declare_links_map_path,
+            declare_gait_config_path,
             declare_orientation_from_imu,
             declare_rviz,
             declare_rviz_ref_frame,
@@ -235,10 +246,11 @@ def generate_launch_description():
             declare_publish_foot_contacts,
             declare_publish_odom_tf,
             declare_close_loop_odom,
-            description_ld,        
+            description_ld,
             quadruped_controller_node,
             state_estimator_node,
             base_to_footprint_ekf,
-            footprint_to_odom_ekf
+            footprint_to_odom_ekf,
+            rviz2
         ]
     )


### PR DESCRIPTION
This patch allows launching RViz with arguments from bringup.launch.py in ROS 2 as well as in ROS 1.

ROS 1: https://github.com/chvmp/champ/blob/cf71f39a550798c003376e54c9ab1cc7f8068bd6/champ_bringup/launch/bringup.launch
ROS 2: https://github.com/chvmp/champ/blob/712a2bb4013fb19ab8cec929d3d9fa05b4ea0090/champ_bringup/launch/bringup.launch.py