### PR TITLE
Fix build error on ROS 2 humble

### DIFF
--- a/champ_base/CMakeLists.txt
+++ b/champ_base/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.5)
 project(champ_base)
 
-add_compile_options(-std=c++14)
+add_compile_options(-std=c++17)
 
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)

--- a/champ_gazebo/CMakeLists.txt
+++ b/champ_gazebo/CMakeLists.txt
@@ -1,30 +1,7 @@
 cmake_minimum_required(VERSION 3.5)
 project(champ_gazebo)
 
-set(ROS2_CONTROL_URL "https://github.com/rohitmenon86/ros2_controllers")
-set(ROS2_CONTROL_DOWNLOAD_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../..)
-set(ROS2_CONTROL_DEPENDENCY_PATH ${ROS2_CONTROL_DOWNLOAD_PATH}/ros2_controllers)
-
-if (NOT EXISTS "${ROS2_CONTROL_DEPENDENCY_PATH}")
-  message(STATUS "Downloading ros2_controllers")
-  message(STATUS "${ROS2_CONTROL_DOWNLOAD_PATH}")
-
-  execute_process(
-    COMMAND git clone ${ROS2_CONTROL_URL} ${ROS2_CONTROL_DEPENDENCY_PATH} -b $ENV{ROS_DISTRO}
-  )
-
-  execute_process(
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../../..
-    COMMAND rosdep install --from-paths src -i -r -y
-  )
-
-  execute_process(
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../../..
-    COMMAND colcon build --packages-select joint_trajectory_controller
-  )
-endif()
-
-add_compile_options(-std=c++14)
+add_compile_options(-std=c++17)
 
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
@@ -32,7 +9,7 @@ find_package(urdf REQUIRED)
 find_package(champ REQUIRED)
 find_package(champ_msgs REQUIRED)
 find_package(gazebo_ros2_control REQUIRED)
-find_package(gazebo REQUIRED)
+find_package(gazebo_ros REQUIRED)
 
 set(dependencies
   rclcpp
@@ -40,7 +17,7 @@ set(dependencies
   champ
   champ_msgs
   gazebo_ros2_control
-  gazebo
+  gazebo_ros
 )
 
 install(PROGRAMS

--- a/champ_gazebo/launch/gazebo.launch.py
+++ b/champ_gazebo/launch/gazebo.launch.py
@@ -134,13 +134,13 @@ def generate_launch_description():
         output='screen',
     )
 
-    load_joint_trajectory_controller = ExecuteProcess(
-        cmd=['ros2', 'control', 'load_controller', '--set-state', 'start',
+    load_joint_trajectory_position_controller = ExecuteProcess(
+        cmd=['ros2', 'control', 'load_controller', '--set-state', 'active',
              'joint_group_position_controller'],
         output='screen'
     )
-    load_joint_trajectory1_controller = ExecuteProcess(
-        cmd=['ros2', 'control', 'load_controller', '--set-state', 'start',
+    load_joint_trajectory_effort_controller = ExecuteProcess(
+        cmd=['ros2', 'control', 'load_controller', '--set-state', 'active',
              'joint_group_effort_controller'],
         output='screen'
     )
@@ -165,8 +165,8 @@ def generate_launch_description():
             start_gazebo_client_cmd,
             start_gazebo_spawner_cmd,
             load_joint_state_controller,
-            # load_joint_trajectory1_controller
-            load_joint_trajectory1_controller,
+            # load_joint_trajectory_position_controller
+            load_joint_trajectory_effort_controller,
             contact_sensor
         ]
     )


### PR DESCRIPTION
This pull request fixes the following errors. This fix depends on https://github.com/chvmp/libchamp/pull/6.

**champ_base** while `colcon build`

```
$ head -n30 log/build_2022-11-27_23-20-32/champ_base/stderr.log 
In file included from /opt/ros/humble/include/rclcpp/rclcpp/callback_group.hpp:23,
                 from /opt/ros/humble/include/rclcpp/rclcpp/any_executable.hpp:20,
                 from /opt/ros/humble/include/rclcpp/rclcpp/memory_strategy.hpp:25,
                 from /opt/ros/humble/include/rclcpp/rclcpp/memory_strategies.hpp:18,
                 from /opt/ros/humble/include/rclcpp/rclcpp/executor_options.hpp:20,
                 from /opt/ros/humble/include/rclcpp/rclcpp/executor.hpp:37,
                 from /opt/ros/humble/include/rclcpp/rclcpp/executors/multi_threaded_executor.hpp:25,
                 from /opt/ros/humble/include/rclcpp/rclcpp/executors.hpp:21,
                 from /opt/ros/humble/include/rclcpp/rclcpp/rclcpp.hpp:155,
                 from /home/daisuke/ros2_ws/src/champ/champ_base/include/message_relay.h:31,
                 from /home/daisuke/ros2_ws/src/champ/champ_base/src/message_relay.cpp:28:
/opt/ros/humble/include/rclcpp/rclcpp/client.hpp:786:36: error: ‘variant’ in namespace ‘std’ does not name a template type
  786 |   using CallbackInfoVariant = std::variant<
      |                                    ^~~~~~~
/opt/ros/humble/include/rclcpp/rclcpp/client.hpp:786:31: note: ‘std::variant’ is only available from C++17 onwards
  786 |   using CallbackInfoVariant = std::variant<
      |                               ^~~
/opt/ros/humble/include/rclcpp/rclcpp/client.hpp:792:52: error: ‘CallbackInfoVariant’ has not been declared
  792 |   async_send_request_impl(const Request & request, CallbackInfoVariant value)
      |                                                    ^~~~~~~~~~~~~~~~~~~
/opt/ros/humble/include/rclcpp/rclcpp/client.hpp:808:8: error: ‘optional’ in namespace ‘std’ does not name a template type
  808 |   std::optional<CallbackInfoVariant>
      |        ^~~~~~~~
/opt/ros/humble/include/rclcpp/rclcpp/client.hpp:808:3: note: ‘std::optional’ is only available from C++17 onwards
  808 |   std::optional<CallbackInfoVariant>
      |   ^~~
In file included from /opt/ros/humble/include/rclcpp/rclcpp/callback_group.hpp:23,
                 from /opt/ros/humble/include/rclcpp/rclcpp/any_executable.hpp:20,
                 from /opt/ros/humble/include/rclcpp/rclcpp/memory_strategy.hpp:25,
                 from /opt/ros/humble/include/rclcpp/rclcpp/memory_strategies.hpp:18,
```

**champ_gazebo** while `colcon build` (1)

```
$ head -n30 log/build_2022-11-27_23-22-40/champ_gazebo/stderr.log 
In file included from /opt/ros/humble/include/rclcpp/rclcpp/callback_group.hpp:23,
                 from /opt/ros/humble/include/rclcpp/rclcpp/any_executable.hpp:20,
                 from /opt/ros/humble/include/rclcpp/rclcpp/memory_strategy.hpp:25,
                 from /opt/ros/humble/include/rclcpp/rclcpp/memory_strategies.hpp:18,
                 from /opt/ros/humble/include/rclcpp/rclcpp/executor_options.hpp:20,
                 from /opt/ros/humble/include/rclcpp/rclcpp/executor.hpp:37,
                 from /opt/ros/humble/include/rclcpp/rclcpp/executors/multi_threaded_executor.hpp:25,
                 from /opt/ros/humble/include/rclcpp/rclcpp/executors.hpp:21,
                 from /opt/ros/humble/include/rclcpp/rclcpp/rclcpp.hpp:155,
                 from /home/daisuke/ros2_ws/src/champ/champ_gazebo/src/contact_sensor.cpp:17:
/opt/ros/humble/include/rclcpp/rclcpp/client.hpp:786:36: error: ‘variant’ in namespace ‘std’ does not name a template type
  786 |   using CallbackInfoVariant = std::variant<
      |                                    ^~~~~~~
/opt/ros/humble/include/rclcpp/rclcpp/client.hpp:786:31: note: ‘std::variant’ is only available from C++17 onwards
  786 |   using CallbackInfoVariant = std::variant<
      |                               ^~~
/opt/ros/humble/include/rclcpp/rclcpp/client.hpp:792:52: error: ‘CallbackInfoVariant’ has not been declared
  792 |   async_send_request_impl(const Request & request, CallbackInfoVariant value)
      |                                                    ^~~~~~~~~~~~~~~~~~~
/opt/ros/humble/include/rclcpp/rclcpp/client.hpp:808:8: error: ‘optional’ in namespace ‘std’ does not name a template type
  808 |   std::optional<CallbackInfoVariant>
      |        ^~~~~~~~
/opt/ros/humble/include/rclcpp/rclcpp/client.hpp:808:3: note: ‘std::optional’ is only available from C++17 onwards
  808 |   std::optional<CallbackInfoVariant>
      |   ^~~
/opt/ros/humble/include/rclcpp/rclcpp/client.hpp:830:7: error: ‘CallbackInfoVariant’ was not declared in this scope
  830 |       CallbackInfoVariant>>
      |       ^~~~~~~~~~~~~~~~~~~
/opt/ros/humble/include/rclcpp/rclcpp/client.hpp:830:7: error: template argument 2 is invalid
/opt/ros/humble/include/rclcpp/rclcpp/client.hpp:830:26: error: template argument 2 is invalid
```

**champ_gazebo** while `colcon build` (2)

```
$ head -n30 log/build_2022-11-27_23-24-36/champ_gazebo/stderr.log 
CMake Warning (dev) at /usr/share/cmake-3.22/Modules/FindPackageHandleStandardArgs.cmake:438 (message):
  The package name passed to `find_package_handle_standard_args` (PkgConfig)
  does not match the name of the calling package (gazebo).  This can lead to
  problems in calling code that expects `find_package` result variables
  (e.g., `_FOUND`) to follow a certain pattern.
Call Stack (most recent call first):
  /usr/share/cmake-3.22/Modules/FindPkgConfig.cmake:99 (find_package_handle_standard_args)
  /usr/lib/x86_64-linux-gnu/cmake/gazebo/gazebo-config.cmake:72 (include)
  CMakeLists.txt:12 (find_package)
This warning is for project developers.  Use -Wno-dev to suppress it.

/usr/bin/ld: CMakeFiles/contact_sensor.dir/src/contact_sensor.cpp.o: undefined reference to symbol '_ZN3tbb6detail2r114notify_waitersEm'
/usr/bin/ld: /lib/x86_64-linux-gnu/libtbb.so.12: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
gmake[2]: *** [CMakeFiles/contact_sensor.dir/build.make:238: contact_sensor] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:137: CMakeFiles/contact_sensor.dir/all] Error 2
gmake: *** [Makefile:146: all] Error 2

```

**champ_gazebo** after `colcon build` and `$ ros2 launch mini_pupper_gazebo gazebo.launch.py`

```
[ros2-9] usage: ros2 control load_controller [-h] [--spin-time SPIN_TIME] [-s]
[ros2-9]                                     [--set-state {configured,active}]
[ros2-9]                                     [-c CONTROLLER_MANAGER]
[ros2-9]                                     [--include-hidden-nodes]
[ros2-9]                                     controller_name
[ros2-9] ros2 control load_controller: error: argument --set-state: invalid choice: 'start' (choose from 'configured', 'active')
[ERROR] [ros2-9]: process has died [pid 104702, exit code 2, cmd 'ros2 control load_controller --set-state start joint_states_controller'].
[ros2-10] usage: ros2 control load_controller [-h] [--spin-time SPIN_TIME] [-s]
[ros2-10]                                     [--set-state {configured,active}]
[ros2-10]                                     [-c CONTROLLER_MANAGER]
[ros2-10]                                     [--include-hidden-nodes]
[ros2-10]                                     controller_name
[ros2-10] ros2 control load_controller: error: argument --set-state: invalid choice: 'start' (choose from 'configured', 'active')
[spawn_entity.py-8] [INFO] [1669559242.802729649] [spawn_entity]: Spawn Entity started
[spawn_entity.py-8] [INFO] [1669559242.803039082] [spawn_entity]: Loading entity published on topic /robot_description
[spawn_entity.py-8] /opt/ros/humble/local/lib/python3.10/dist-packages/rclpy/qos.py:307: UserWarning: DurabilityPolicy.RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL is deprecated. Use DurabilityPolicy.TRANSIENT_LOCAL instead.
[spawn_entity.py-8]   warnings.warn(
[spawn_entity.py-8] [INFO] [1669559242.804615664] [spawn_entity]: Waiting for entity xml on /robot_description
[ERROR] [ros2-10]: process has died [pid 104705, exit code 2, cmd 'ros2 control load_controller --set-state start joint_group_effort_controller'].
```


https://user-images.githubusercontent.com/3256629/204141344-152af0dd-9ba7-458a-bfce-575b3075b4b4.mp4

https://user-images.githubusercontent.com/3256629/204141357-fe471cc2-7f2b-42f5-b189-6961644a7301.mp4