### PR TITLE
Fix odom pose

### DIFF
--- a/champ_base/src/state_estimation.cpp
+++ b/champ_base/src/state_estimation.cpp
@@ -36,6 +36,9 @@ StateEstimation::StateEstimation():
     Node("state_estimation_node",rclcpp::NodeOptions()
                         .allow_undeclared_parameters(true)
                         .automatically_declare_parameters_from_overrides(true)),
+    x_pos_(0.0),
+    y_pos_(0.0),
+    heading_(0.0),
     clock_(*this->get_clock()),
     odometry_(base_, rosTimeToChampTime(clock_.now()))
 {
@@ -151,7 +154,7 @@ void StateEstimation::publishFootprintToOdom_()
 
     rclcpp::Time current_time = clock_.now();
 
-    double vel_dt = (current_time - last_vel_time_).nanoseconds()/1e-9;
+    double vel_dt = (current_time - last_vel_time_).nanoseconds() * 1e-9; //s
     last_vel_time_ = current_time;
     //rotate in the z axis
     //https://en.wikipedia.org/wiki/Rotation_matrix


### PR DESCRIPTION
While trying to run navigation using this repo, noticed the incorrect output value of `/odom/raw` and fixed it.

Output of odometry before modification:
```
$ ros2 topic echo /odom/raw
...
pose:
  pose:
    position:
      x: 2.0621076296018528e-19
      y: 2.996481448410523e+32
      z: 0.0
    orientation:
      x: 0.0
      y: 0.0
      z: 2.951125177563796e-10
      w: 1.0
...
```