### PR TITLE
Updated to std+17 to avoid build errors

### DIFF
--- a/champ_base/CMakeLists.txt
+++ b/champ_base/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(champ_base)
 
-add_compile_options(-std=c++11)
+add_compile_options(-std=c++17)
 
 find_package(catkin 
     REQUIRED 

--- a/champ_gazebo/CMakeLists.txt
+++ b/champ_gazebo/CMakeLists.txt
@@ -2,7 +2,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(champ_gazebo)
 
-add_compile_options(-std=c++11)
+add_compile_options(-std=c++17)
 
 find_package(gazebo REQUIRED)
 


### PR DESCRIPTION
This small PR updates the 'add_compile_options' in CMakeLists from +11 to +17 to avoid standard library missing functions errors (is_same_v vs. is_same, std::optional etc.) in ROS Noetic. 


